### PR TITLE
Fixes lock-file, which wasn't up to-do-date after package has been renamed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "airtable-formulator",
+  "name": "@qualifyze/airtable-formulator",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -34,5 +34,20 @@
   },
   "files": [
     "lib"
-  ]
+  ],
+  "directories": {
+    "lib": "lib"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Qualifyze/airtable-formulator.git"
+  },
+  "keywords": [
+    "airtable"
+  ],
+  "author": "",
+  "bugs": {
+    "url": "https://github.com/Qualifyze/airtable-formulator/issues"
+  },
+  "homepage": "https://github.com/Qualifyze/airtable-formulator#readme"
 }


### PR DESCRIPTION
This should have no impact other than avoiding the confusion for devs that their package-lock file has changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/airtable-formulator/1)
<!-- Reviewable:end -->
