### PR TITLE
Adds entry to inform github about the published package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   "bugs": {
     "url": "https://github.com/Qualifyze/airtable-formulator/issues"
   },
-  "homepage": "https://github.com/Qualifyze/airtable-formulator#readme"
+  "homepage": "https://github.com/Qualifyze/airtable-formulator#readme",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }


### PR DESCRIPTION
The only impact here is that github will show where the package was published. https://docs.github.com/en/packages/guides/configuring-npm-for-use-with-github-packages#publishing-a-package-using-publishconfig-in-the-packagejson-file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/airtable-formulator/2)
<!-- Reviewable:end -->
