### PR TITLE
Revert "Adds entry to inform github about the published package."

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,5 @@
   "bugs": {
     "url": "https://github.com/Qualifyze/airtable-formulator/issues"
   },
-  "homepage": "https://github.com/Qualifyze/airtable-formulator#readme",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  }
+  "homepage": "https://github.com/Qualifyze/airtable-formulator#readme"
 }


### PR DESCRIPTION
Reverts Qualifyze/airtable-formulator#2 - wrong repository

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/airtable-formulator/3)
<!-- Reviewable:end -->
