### PR TITLE
Tokenizer for airtable formula AST parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./schema";
 export * from "./compiler";
+export * from "./tokenize";

--- a/src/tests/tokenize.test.ts
+++ b/src/tests/tokenize.test.ts
@@ -1,0 +1,1164 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { tokenize } from "../tokenize";
+
+describe("tokenize()", () => {
+  it("Should tokenize a simple formula", () => {
+    expect(tokenize("1 + 2")).toMatchInlineSnapshot(`
+      Object {
+        "end": 5,
+        "members": Array [
+          Object {
+            "end": 1,
+            "start": 0,
+            "type": "number",
+            "value": "1",
+          },
+          Object {
+            "end": 2,
+            "start": 1,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 3,
+            "start": 2,
+            "type": "operator",
+            "value": "+",
+          },
+          Object {
+            "end": 4,
+            "start": 3,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 5,
+            "start": 4,
+            "type": "number",
+            "value": "2",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "1 + 2",
+      }
+    `);
+  });
+
+  it("Should tokenize a formula with decimal numbers", () => {
+    expect(tokenize("1.5 + 2.5")).toMatchInlineSnapshot(`
+      Object {
+        "end": 9,
+        "members": Array [
+          Object {
+            "end": 3,
+            "start": 0,
+            "type": "number",
+            "value": "1.5",
+          },
+          Object {
+            "end": 4,
+            "start": 3,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 5,
+            "start": 4,
+            "type": "operator",
+            "value": "+",
+          },
+          Object {
+            "end": 6,
+            "start": 5,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 9,
+            "start": 6,
+            "type": "number",
+            "value": "2.5",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "1.5 + 2.5",
+      }
+    `);
+  });
+
+  it("Should tokenize a minus operator over a negative number", () => {
+    expect(tokenize("-1-2")).toMatchInlineSnapshot(`
+      Object {
+        "end": 4,
+        "members": Array [
+          Object {
+            "end": 1,
+            "start": 0,
+            "type": "operator",
+            "value": "-",
+          },
+          Object {
+            "end": 2,
+            "start": 1,
+            "type": "number",
+            "value": "1",
+          },
+          Object {
+            "end": 3,
+            "start": 2,
+            "type": "operator",
+            "value": "-",
+          },
+          Object {
+            "end": 4,
+            "start": 3,
+            "type": "number",
+            "value": "2",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "-1-2",
+      }
+    `);
+  });
+
+  it("Should tokenize a formula with a string", () => {
+    expect(tokenize("1 + 'Hello world'")).toMatchInlineSnapshot(`
+      Object {
+        "end": 17,
+        "members": Array [
+          Object {
+            "end": 1,
+            "start": 0,
+            "type": "number",
+            "value": "1",
+          },
+          Object {
+            "end": 2,
+            "start": 1,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 3,
+            "start": 2,
+            "type": "operator",
+            "value": "+",
+          },
+          Object {
+            "end": 4,
+            "start": 3,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "closer": Object {
+              "end": 17,
+              "start": 16,
+              "type": "quoteMark",
+              "value": "'",
+            },
+            "end": 16,
+            "members": Array [],
+            "opener": Object {
+              "end": 5,
+              "start": 4,
+              "type": "quoteMark",
+              "value": "'",
+            },
+            "start": 5,
+            "type": "string",
+            "value": "Hello world",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "1 + 'Hello world'",
+      }
+    `);
+  });
+
+  it("Should tokenize a formula with a field reference", () => {
+    expect(tokenize("1 + myField")).toMatchInlineSnapshot(`
+      Object {
+        "end": 11,
+        "members": Array [
+          Object {
+            "end": 1,
+            "start": 0,
+            "type": "number",
+            "value": "1",
+          },
+          Object {
+            "end": 2,
+            "start": 1,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 3,
+            "start": 2,
+            "type": "operator",
+            "value": "+",
+          },
+          Object {
+            "end": 4,
+            "start": 3,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 11,
+            "start": 4,
+            "type": "reference",
+            "value": "myField",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "1 + myField",
+      }
+    `);
+  });
+
+  it("Should tokenize a formula with a function call", () => {
+    expect(tokenize("1 + SUM(2, 3)")).toMatchInlineSnapshot(`
+      Object {
+        "end": 13,
+        "members": Array [
+          Object {
+            "end": 1,
+            "start": 0,
+            "type": "number",
+            "value": "1",
+          },
+          Object {
+            "end": 2,
+            "start": 1,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 3,
+            "start": 2,
+            "type": "operator",
+            "value": "+",
+          },
+          Object {
+            "end": 4,
+            "start": 3,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 7,
+            "start": 4,
+            "type": "reference",
+            "value": "SUM",
+          },
+          Object {
+            "closer": Object {
+              "end": 13,
+              "start": 12,
+              "type": "closeParenthesis",
+              "value": ")",
+            },
+            "end": 12,
+            "members": Array [
+              Object {
+                "end": 9,
+                "start": 8,
+                "type": "number",
+                "value": "2",
+              },
+              Object {
+                "end": 10,
+                "start": 9,
+                "type": "argumentSeparator",
+                "value": ",",
+              },
+              Object {
+                "end": 11,
+                "start": 10,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "end": 12,
+                "start": 11,
+                "type": "number",
+                "value": "3",
+              },
+            ],
+            "opener": Object {
+              "end": 8,
+              "start": 7,
+              "type": "openParenthesis",
+              "value": "(",
+            },
+            "start": 8,
+            "type": "group",
+            "value": "2, 3",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "1 + SUM(2, 3)",
+      }
+    `);
+  });
+
+  it("Should tokenize braced references", () => {
+    expect(tokenize("MIN({Regular Price}, {Sale Price})"))
+      .toMatchInlineSnapshot(`
+      Object {
+        "end": 34,
+        "members": Array [
+          Object {
+            "end": 3,
+            "start": 0,
+            "type": "reference",
+            "value": "MIN",
+          },
+          Object {
+            "closer": Object {
+              "end": 34,
+              "start": 33,
+              "type": "closeParenthesis",
+              "value": ")",
+            },
+            "end": 33,
+            "members": Array [
+              Object {
+                "closer": Object {
+                  "end": 19,
+                  "start": 18,
+                  "type": "closeBrace",
+                  "value": "}",
+                },
+                "end": 18,
+                "members": Array [],
+                "opener": Object {
+                  "end": 5,
+                  "start": 4,
+                  "type": "openBrace",
+                  "value": "{",
+                },
+                "start": 5,
+                "type": "reference",
+                "value": "Regular Price",
+              },
+              Object {
+                "end": 20,
+                "start": 19,
+                "type": "argumentSeparator",
+                "value": ",",
+              },
+              Object {
+                "end": 21,
+                "start": 20,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "closer": Object {
+                  "end": 33,
+                  "start": 32,
+                  "type": "closeBrace",
+                  "value": "}",
+                },
+                "end": 32,
+                "members": Array [],
+                "opener": Object {
+                  "end": 22,
+                  "start": 21,
+                  "type": "openBrace",
+                  "value": "{",
+                },
+                "start": 22,
+                "type": "reference",
+                "value": "Sale Price",
+              },
+            ],
+            "opener": Object {
+              "end": 4,
+              "start": 3,
+              "type": "openParenthesis",
+              "value": "(",
+            },
+            "start": 4,
+            "type": "group",
+            "value": ", ",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "MIN({Regular Price}, {Sale Price})",
+      }
+    `);
+  });
+
+  it("Should tokenize a formula with a function call with a field reference", () => {
+    expect(tokenize("1 + SUM(myField, 3)")).toMatchInlineSnapshot(`
+      Object {
+        "end": 19,
+        "members": Array [
+          Object {
+            "end": 1,
+            "start": 0,
+            "type": "number",
+            "value": "1",
+          },
+          Object {
+            "end": 2,
+            "start": 1,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 3,
+            "start": 2,
+            "type": "operator",
+            "value": "+",
+          },
+          Object {
+            "end": 4,
+            "start": 3,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 7,
+            "start": 4,
+            "type": "reference",
+            "value": "SUM",
+          },
+          Object {
+            "closer": Object {
+              "end": 19,
+              "start": 18,
+              "type": "closeParenthesis",
+              "value": ")",
+            },
+            "end": 18,
+            "members": Array [
+              Object {
+                "end": 15,
+                "start": 8,
+                "type": "reference",
+                "value": "myField",
+              },
+              Object {
+                "end": 16,
+                "start": 15,
+                "type": "argumentSeparator",
+                "value": ",",
+              },
+              Object {
+                "end": 17,
+                "start": 16,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "end": 18,
+                "start": 17,
+                "type": "number",
+                "value": "3",
+              },
+            ],
+            "opener": Object {
+              "end": 8,
+              "start": 7,
+              "type": "openParenthesis",
+              "value": "(",
+            },
+            "start": 8,
+            "type": "group",
+            "value": "myField, 3",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "1 + SUM(myField, 3)",
+      }
+    `);
+  });
+
+  it("Should tokenize a formula with parenthesis", () => {
+    expect(tokenize("(1 + 2) * 3")).toMatchInlineSnapshot(`
+      Object {
+        "end": 11,
+        "members": Array [
+          Object {
+            "closer": Object {
+              "end": 7,
+              "start": 6,
+              "type": "closeParenthesis",
+              "value": ")",
+            },
+            "end": 6,
+            "members": Array [
+              Object {
+                "end": 2,
+                "start": 1,
+                "type": "number",
+                "value": "1",
+              },
+              Object {
+                "end": 3,
+                "start": 2,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "end": 4,
+                "start": 3,
+                "type": "operator",
+                "value": "+",
+              },
+              Object {
+                "end": 5,
+                "start": 4,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "end": 6,
+                "start": 5,
+                "type": "number",
+                "value": "2",
+              },
+            ],
+            "opener": Object {
+              "end": 1,
+              "start": 0,
+              "type": "openParenthesis",
+              "value": "(",
+            },
+            "start": 1,
+            "type": "group",
+            "value": "1 + 2",
+          },
+          Object {
+            "end": 8,
+            "start": 7,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 9,
+            "start": 8,
+            "type": "operator",
+            "value": "*",
+          },
+          Object {
+            "end": 10,
+            "start": 9,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 11,
+            "start": 10,
+            "type": "number",
+            "value": "3",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "(1 + 2) * 3",
+      }
+    `);
+  });
+
+  it("Should tokenize a formula with a new lines", () => {
+    expect(
+      tokenize(`IF(
+      {Sales Tax} * {Price} > 100,
+      "This is over 100",
+      "This is less than 100"
+    )`)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "end": 100,
+        "members": Array [
+          Object {
+            "end": 2,
+            "start": 0,
+            "type": "reference",
+            "value": "IF",
+          },
+          Object {
+            "closer": Object {
+              "end": 100,
+              "start": 99,
+              "type": "closeParenthesis",
+              "value": ")",
+            },
+            "end": 99,
+            "members": Array [
+              Object {
+                "end": 10,
+                "start": 3,
+                "type": "space",
+                "value": "
+            ",
+              },
+              Object {
+                "closer": Object {
+                  "end": 21,
+                  "start": 20,
+                  "type": "closeBrace",
+                  "value": "}",
+                },
+                "end": 20,
+                "members": Array [],
+                "opener": Object {
+                  "end": 11,
+                  "start": 10,
+                  "type": "openBrace",
+                  "value": "{",
+                },
+                "start": 11,
+                "type": "reference",
+                "value": "Sales Tax",
+              },
+              Object {
+                "end": 22,
+                "start": 21,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "end": 23,
+                "start": 22,
+                "type": "operator",
+                "value": "*",
+              },
+              Object {
+                "end": 24,
+                "start": 23,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "closer": Object {
+                  "end": 31,
+                  "start": 30,
+                  "type": "closeBrace",
+                  "value": "}",
+                },
+                "end": 30,
+                "members": Array [],
+                "opener": Object {
+                  "end": 25,
+                  "start": 24,
+                  "type": "openBrace",
+                  "value": "{",
+                },
+                "start": 25,
+                "type": "reference",
+                "value": "Price",
+              },
+              Object {
+                "end": 32,
+                "start": 31,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "end": 33,
+                "start": 32,
+                "type": "operator",
+                "value": ">",
+              },
+              Object {
+                "end": 34,
+                "start": 33,
+                "type": "space",
+                "value": " ",
+              },
+              Object {
+                "end": 37,
+                "start": 34,
+                "type": "number",
+                "value": "100",
+              },
+              Object {
+                "end": 38,
+                "start": 37,
+                "type": "argumentSeparator",
+                "value": ",",
+              },
+              Object {
+                "end": 45,
+                "start": 38,
+                "type": "space",
+                "value": "
+            ",
+              },
+              Object {
+                "closer": Object {
+                  "end": 63,
+                  "start": 62,
+                  "type": "quoteMark",
+                  "value": "\\"",
+                },
+                "end": 62,
+                "members": Array [],
+                "opener": Object {
+                  "end": 46,
+                  "start": 45,
+                  "type": "quoteMark",
+                  "value": "\\"",
+                },
+                "start": 46,
+                "type": "string",
+                "value": "This is over 100",
+              },
+              Object {
+                "end": 64,
+                "start": 63,
+                "type": "argumentSeparator",
+                "value": ",",
+              },
+              Object {
+                "end": 71,
+                "start": 64,
+                "type": "space",
+                "value": "
+            ",
+              },
+              Object {
+                "closer": Object {
+                  "end": 94,
+                  "start": 93,
+                  "type": "quoteMark",
+                  "value": "\\"",
+                },
+                "end": 93,
+                "members": Array [],
+                "opener": Object {
+                  "end": 72,
+                  "start": 71,
+                  "type": "quoteMark",
+                  "value": "\\"",
+                },
+                "start": 72,
+                "type": "string",
+                "value": "This is less than 100",
+              },
+              Object {
+                "end": 99,
+                "start": 94,
+                "type": "space",
+                "value": "
+          ",
+              },
+            ],
+            "opener": Object {
+              "end": 3,
+              "start": 2,
+              "type": "openParenthesis",
+              "value": "(",
+            },
+            "start": 3,
+            "type": "group",
+            "value": "
+             *  > 100,
+            ,
+            
+          ",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "IF(
+            {Sales Tax} * {Price} > 100,
+            \\"This is over 100\\",
+            \\"This is less than 100\\"
+          )",
+      }
+    `);
+  });
+
+  it("Should tokenize a string with escaped quotes", () => {
+    expect(tokenize(`"This is a \\"string\\""`)).toMatchInlineSnapshot(`
+      Object {
+        "end": 22,
+        "members": Array [
+          Object {
+            "closer": Object {
+              "end": 22,
+              "start": 21,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "end": 21,
+            "members": Array [],
+            "opener": Object {
+              "end": 1,
+              "start": 0,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "start": 1,
+            "type": "string",
+            "value": "This is a \\\\\\"string\\\\\\"",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "\\"This is a \\\\\\"string\\\\\\"\\"",
+      }
+    `);
+  });
+
+  it("Should tokenize mixed quotes", () => {
+    expect(tokenize(`"'"`)).toMatchInlineSnapshot(`
+      Object {
+        "end": 3,
+        "members": Array [
+          Object {
+            "closer": Object {
+              "end": 3,
+              "start": 2,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "end": 2,
+            "members": Array [],
+            "opener": Object {
+              "end": 1,
+              "start": 0,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "start": 1,
+            "type": "string",
+            "value": "'",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "\\"'\\"",
+      }
+    `);
+
+    expect(tokenize(`'"'`)).toMatchInlineSnapshot(`
+      Object {
+        "end": 3,
+        "members": Array [
+          Object {
+            "closer": Object {
+              "end": 3,
+              "start": 2,
+              "type": "quoteMark",
+              "value": "'",
+            },
+            "end": 2,
+            "members": Array [],
+            "opener": Object {
+              "end": 1,
+              "start": 0,
+              "type": "quoteMark",
+              "value": "'",
+            },
+            "start": 1,
+            "type": "string",
+            "value": "\\"",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "'\\"'",
+      }
+    `);
+  });
+
+  it("Should not tokenize special characters in strings", () => {
+    expect(tokenize(`"(){}''"`)).toMatchInlineSnapshot(`
+      Object {
+        "end": 8,
+        "members": Array [
+          Object {
+            "closer": Object {
+              "end": 8,
+              "start": 7,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "end": 7,
+            "members": Array [],
+            "opener": Object {
+              "end": 1,
+              "start": 0,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "start": 1,
+            "type": "string",
+            "value": "(){}''",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "\\"(){}''\\"",
+      }
+    `);
+    expect(tokenize(`foo("(){}''")`)).toMatchInlineSnapshot(`
+      Object {
+        "end": 13,
+        "members": Array [
+          Object {
+            "end": 3,
+            "start": 0,
+            "type": "reference",
+            "value": "foo",
+          },
+          Object {
+            "closer": Object {
+              "end": 13,
+              "start": 12,
+              "type": "closeParenthesis",
+              "value": ")",
+            },
+            "end": 12,
+            "members": Array [
+              Object {
+                "closer": Object {
+                  "end": 12,
+                  "start": 11,
+                  "type": "quoteMark",
+                  "value": "\\"",
+                },
+                "end": 11,
+                "members": Array [],
+                "opener": Object {
+                  "end": 5,
+                  "start": 4,
+                  "type": "quoteMark",
+                  "value": "\\"",
+                },
+                "start": 5,
+                "type": "string",
+                "value": "(){}''",
+              },
+            ],
+            "opener": Object {
+              "end": 4,
+              "start": 3,
+              "type": "openParenthesis",
+              "value": "(",
+            },
+            "start": 4,
+            "type": "group",
+            "value": "",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "foo(\\"(){}''\\")",
+      }
+    `);
+  });
+
+  it("Should tokenize a string with escaped backlash", () => {
+    expect(tokenize(`"\\\\"`)).toMatchInlineSnapshot(`
+      Object {
+        "end": 4,
+        "members": Array [
+          Object {
+            "closer": Object {
+              "end": 4,
+              "start": 3,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "end": 3,
+            "members": Array [],
+            "opener": Object {
+              "end": 1,
+              "start": 0,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "start": 1,
+            "type": "string",
+            "value": "\\\\\\\\",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "\\"\\\\\\\\\\"",
+      }
+    `);
+  });
+
+  it("Should tokenize triple operators", () => {
+    expect(tokenize(`Name & " - " & Age`)).toMatchInlineSnapshot(`
+      Object {
+        "end": 18,
+        "members": Array [
+          Object {
+            "end": 4,
+            "start": 0,
+            "type": "reference",
+            "value": "Name",
+          },
+          Object {
+            "end": 5,
+            "start": 4,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 6,
+            "start": 5,
+            "type": "operator",
+            "value": "&",
+          },
+          Object {
+            "end": 7,
+            "start": 6,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "closer": Object {
+              "end": 12,
+              "start": 11,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "end": 11,
+            "members": Array [],
+            "opener": Object {
+              "end": 8,
+              "start": 7,
+              "type": "quoteMark",
+              "value": "\\"",
+            },
+            "start": 8,
+            "type": "string",
+            "value": " - ",
+          },
+          Object {
+            "end": 13,
+            "start": 12,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 14,
+            "start": 13,
+            "type": "operator",
+            "value": "&",
+          },
+          Object {
+            "end": 15,
+            "start": 14,
+            "type": "space",
+            "value": " ",
+          },
+          Object {
+            "end": 18,
+            "start": 15,
+            "type": "reference",
+            "value": "Age",
+          },
+        ],
+        "start": 0,
+        "type": "group",
+        "value": "Name & \\" - \\" & Age",
+      }
+    `);
+  });
+
+  it("Should throw on unbalanced quotes", () => {
+    expect(() =>
+      tokenize(`"This is a "string"`)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"SyntaxError: Unclosed token doubleQuotedString, with \\" at position 18, but no closing token at position 19"`
+    );
+  });
+
+  it("Should throw on unbalanced field reference", () => {
+    expect(() =>
+      tokenize(`{this is a field`)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"SyntaxError: Unclosed token bracedReference, with { at position 0, but no closing token at position 16"`
+    );
+  });
+
+  it("Should throw on unbalanced parentheses", () => {
+    expect(() => tokenize(`IF(1, 2, 3`)).toThrowErrorMatchingInlineSnapshot(
+      `"SyntaxError: Unclosed token group, with ( at position 2, but no closing token at position 10"`
+    );
+    expect(() => tokenize(`IF1, 2, 3)`)).toThrowErrorMatchingInlineSnapshot(
+      `"Syntax Error: Unexpected closing token ) at 9"`
+    );
+  });
+
+  it("Should throw on invalid tokens", () => {
+    // Invalid []
+    expect(() => tokenize(`[`)).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 0 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"[\\""
+    `);
+    expect(() => tokenize(`]`)).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 0 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"]\\""
+    `);
+    expect(() => tokenize(`a[1`)).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 1 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"[1\\""
+    `);
+    expect(() => tokenize(`IF[1, 2, 3]`)).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 2 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"[1, 2, 3]\\""
+    `);
+    // Invalid ``
+    expect(() => tokenize("`")).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 0 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"\`\\""
+    `);
+    expect(() => tokenize("`Hello World`")).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 0 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"\`Hello World\`\\""
+    `);
+    // Invalid operator %
+    expect(() => tokenize(`%`)).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 0 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"%\\""
+    `);
+    expect(() => tokenize(`a%b`)).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 1 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"%b\\""
+    `);
+    // Invalid operator $
+    expect(() => tokenize(`$`)).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 0 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"$\\""
+    `);
+    expect(() => tokenize(`a$b`)).toThrowErrorMatchingInlineSnapshot(`
+      "Syntax error at position 1 for group:
+      	Expected: openDoubleQuote (/\\"/), openSingleQuote (/'/), openParenthesis (/\\\\(/), openBrace (/\\\\{/), closeParenthesis (/\\\\)/), number (/\\\\d+(?:\\\\.\\\\d+)?/), argumentSeparator (/,/), operator (/&|>|<|>=|<=|=|!=|\\\\+|-|\\\\*|\\\\//), reference (/\\\\b[a-z]\\\\w*/i), space (/\\\\s+/), group (/[]/)
+      	Got: \\"$b\\""
+    `);
+  });
+});

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -1,0 +1,507 @@
+import { operators } from "./airtable-formula-reference.json";
+
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// convert operators to a regexp matcher
+export const operatorMatcher = new RegExp(
+  Object.keys(operators)
+    .map((op) => escapeRegExp(op))
+    .join("|")
+);
+
+const workingTokens = [
+  "escapedSingleQuote",
+  "escapedDoubleQuote",
+  "escapedBackslash",
+  "openSingleQuote",
+  "closeSingleQuote",
+  "openDoubleQuote",
+  "closeDoubleQuote",
+  "singleQuotedString",
+  "doubleQuotedString",
+  "bracedReference",
+] as const;
+
+const tokenNames = [
+  "space",
+  "number",
+  "string",
+  "quoteMark",
+  "operator",
+  "openParenthesis",
+  "closeParenthesis",
+  "openBrace",
+  "closeBrace",
+  "reference",
+  "argumentSeparator",
+  "group",
+] as const;
+
+export type TokenTypeName = typeof tokenNames[number];
+
+type WorkingTokenTypeName = TokenTypeName | typeof workingTokens[number];
+
+function isWorkingTokenTypeName(type: string): type is WorkingTokenTypeName {
+  return [...tokenNames, ...workingTokens].includes(
+    type as WorkingTokenTypeName
+  );
+}
+
+export function isTokenName(token: string): token is TokenTypeName {
+  return tokenNames.includes(token as TokenTypeName);
+}
+
+type TokenType = (
+  | { type: WorkingTokenTypeName; finalType: TokenTypeName }
+  | { type: TokenTypeName; finalType?: TokenTypeName }
+) & {
+  on: RegExp;
+  onlyIn?: WorkingTokenTypeName;
+};
+
+type OpeningTokenType = TokenType & {
+  opens: WorkingTokenTypeName;
+  closes?: never;
+  memberOf?: never;
+};
+
+type ClosingTokenType = TokenType & {
+  opens?: never;
+  closes: WorkingTokenTypeName;
+  memberOf?: never;
+};
+
+type MemberTokenType = TokenType & {
+  opens?: never;
+  closes?: never;
+  memberOf: WorkingTokenTypeName;
+  flatten?: boolean;
+};
+
+type EnclosedToken = TokenType & {
+  opens?: never;
+  closes?: never;
+  memberOf?: never;
+  flatten?: never;
+};
+
+function isOpening(token: TokenType): token is OpeningTokenType {
+  const { opens, closes, memberOf } = token as unknown as Record<
+    string,
+    unknown
+  >;
+  return (
+    typeof opens === "string" &&
+    isWorkingTokenTypeName(opens) &&
+    !closes &&
+    !memberOf
+  );
+}
+
+function isClosing(token: TokenType): token is ClosingTokenType {
+  const { opens, closes, memberOf } = token as unknown as Record<
+    string,
+    unknown
+  >;
+  return (
+    typeof closes === "string" &&
+    isWorkingTokenTypeName(closes) &&
+    !opens &&
+    !memberOf
+  );
+}
+
+function isMember(token: TokenType): token is MemberTokenType {
+  const { opens, closes, memberOf } = token as unknown as Record<
+    string,
+    unknown
+  >;
+  return (
+    typeof memberOf === "string" &&
+    isWorkingTokenTypeName(memberOf) &&
+    !opens &&
+    !closes
+  );
+}
+
+function isEnclosed(token: TokenType): token is EnclosedToken {
+  const { opens, closes, memberOf } = token as unknown as Record<
+    string,
+    unknown
+  >;
+  return typeof !memberOf && !opens && !closes;
+}
+
+const openingTokens: readonly OpeningTokenType[] = [
+  {
+    type: "openDoubleQuote",
+    finalType: "quoteMark",
+    on: /"/,
+    opens: "doubleQuotedString",
+    onlyIn: "group",
+  },
+  {
+    type: "openSingleQuote",
+    finalType: "quoteMark",
+    on: /'/,
+    opens: "singleQuotedString",
+    onlyIn: "group",
+  },
+  {
+    type: "openParenthesis",
+    on: /\(/,
+    opens: "group",
+    onlyIn: "group",
+  },
+  {
+    type: "openBrace",
+    on: /\{/,
+    opens: "bracedReference",
+    onlyIn: "group",
+  },
+] as const;
+
+const closingTokens: readonly ClosingTokenType[] = [
+  {
+    type: "closeDoubleQuote",
+    finalType: "quoteMark",
+    on: /"/,
+    closes: "doubleQuotedString",
+  },
+  {
+    type: "closeSingleQuote",
+    finalType: "quoteMark",
+    on: /'/,
+    closes: "singleQuotedString",
+  },
+  {
+    type: "closeParenthesis",
+    on: /\)/,
+    closes: "group",
+  },
+  {
+    type: "closeBrace",
+    on: /}/,
+    closes: "bracedReference",
+  },
+] as const;
+
+const memberTokens: readonly MemberTokenType[] = [
+  {
+    type: "escapedBackslash",
+    finalType: "string",
+    on: /(?:\\{2})+/,
+    flatten: true,
+    memberOf: "doubleQuotedString",
+  },
+  {
+    type: "escapedBackslash",
+    finalType: "string",
+    on: /(?:\\{2})+/,
+    flatten: true,
+    memberOf: "singleQuotedString",
+  },
+  {
+    type: "escapedDoubleQuote",
+    finalType: "string",
+    on: /\\"/,
+    memberOf: "doubleQuotedString",
+    flatten: true,
+  },
+  {
+    type: "escapedSingleQuote",
+    finalType: "string",
+    on: /\\''/,
+    memberOf: "singleQuotedString",
+    flatten: true,
+  },
+  {
+    type: "number",
+    on: /\d+(?:\.\d+)?/,
+    memberOf: "group",
+  },
+  {
+    type: "argumentSeparator",
+    on: /,/,
+    memberOf: "group",
+  },
+  {
+    type: "operator",
+    on: operatorMatcher,
+    memberOf: "group",
+  },
+  {
+    type: "reference",
+    // The Assumption is that a reference may not contain special characters
+    // So that refs like `$myField` or `%myField` are not allowed, unless they
+    // are braced with `{}`.
+    on: /\b[a-z]\w*/i,
+    memberOf: "group",
+  },
+  {
+    type: "space",
+    on: /\s+/,
+    memberOf: "group",
+  },
+] as const;
+
+const enclosedTokens: readonly EnclosedToken[] = [
+  {
+    type: "bracedReference",
+    finalType: "reference",
+    on: /[^{}]+/,
+  },
+  {
+    type: "doubleQuotedString",
+    finalType: "string",
+    on: /[^"\\]+/,
+  },
+  {
+    type: "singleQuotedString",
+    finalType: "string",
+    on: /[^']+/,
+  },
+  {
+    type: "group",
+    // eslint-disable-next-line no-empty-character-class
+    on: /[]/, // Everything should have been matched by now. So anything else is an error.
+  },
+] as const;
+
+const tokenTypes = [
+  ...openingTokens,
+  ...closingTokens,
+  ...memberTokens,
+  ...enclosedTokens,
+] as const;
+
+type DirtyToken = {
+  type: WorkingTokenTypeName;
+  value: string;
+  start: number;
+  end: number;
+  opener?: DirtyToken;
+  closer?: DirtyToken;
+  members?: DirtyToken[];
+};
+
+export type Token = Omit<
+  DirtyToken,
+  "type" | "opener" | "closer" | "members"
+> & {
+  type: TokenTypeName;
+  opener?: Token;
+  closer?: Token;
+  members?: Token[];
+};
+
+type StartedToken = Omit<DirtyToken, "end"> &
+  Partial<DirtyToken> &
+  Required<Pick<DirtyToken, "members">>;
+
+function finalizeToken({
+  type,
+  opener,
+  closer,
+  members,
+  ...rest
+}: Readonly<DirtyToken>): Token {
+  const typeDef = tokenTypes.find((t) => t.type === type);
+
+  if (!typeDef) {
+    throw new Error(`Unknown token type: ${type}`);
+  }
+
+  return {
+    type: typeDef.finalType || typeDef.type,
+    ...Object.fromEntries(
+      [
+        ["opener", opener && finalizeToken(opener)],
+        ["closer", closer && finalizeToken(closer)],
+        ["members", members && members.map(finalizeToken)],
+      ].filter(([, value]) => value !== undefined)
+    ),
+    ...rest,
+  };
+}
+
+function createTokenFromMatch(
+  type: WorkingTokenTypeName | TokenTypeName,
+  match: RegExpExecArray,
+  offset = 0
+): DirtyToken {
+  return {
+    type,
+    start: offset + match.index,
+    end: offset + match.index + match[0].length,
+    value: match[0],
+  };
+}
+
+function isToken(obj: Record<string, unknown>): obj is Token {
+  const { type, start, end, value } = obj;
+
+  return (
+    typeof type === "string" &&
+    isTokenName(type) &&
+    typeof start === "number" &&
+    typeof end === "number" &&
+    typeof value === "string"
+  );
+}
+
+function closeEnclosedToken(
+  currentToken: StartedToken,
+  closer: DirtyToken
+): DirtyToken {
+  return {
+    ...currentToken,
+    closer,
+    end: closer.start,
+  };
+}
+
+function appendToken(
+  group: StartedToken,
+  member: DirtyToken,
+  addMember = true
+) {
+  if (!group.end) {
+    group.value += member.value;
+  }
+  if (addMember) {
+    group.members.push(member);
+  }
+}
+
+function getApplicableTypes(currentToken: StartedToken) {
+  return tokenTypes.filter(
+    ({ type, closes, memberOf, onlyIn }) =>
+      type === currentToken.type ||
+      (closes && closes === currentToken.type) ||
+      (memberOf && memberOf === currentToken.type) ||
+      (onlyIn && onlyIn === currentToken.type)
+  );
+}
+
+function findNextToken(
+  applicableTypes: (
+    | OpeningTokenType
+    | ClosingTokenType
+    | MemberTokenType
+    | EnclosedToken
+  )[],
+  remaining: string,
+  i: number,
+  currentToken: Omit<DirtyToken, "end"> &
+    Partial<DirtyToken> &
+    Required<Pick<DirtyToken, "members">>
+) {
+  const matches = applicableTypes
+    .map((tokenType) => ({ match: tokenType.on.exec(remaining), tokenType }))
+    .filter(({ match }) => match?.index === 0) as {
+    match: RegExpExecArray;
+    tokenType: TokenType;
+  }[];
+
+  if (matches.length === 0) {
+    throw new Error(
+      `Syntax error at position ${i} for ${
+        currentToken.type
+      }:\n\tExpected: ${applicableTypes
+        .map(({ type, on }) => `${type} (${on})`)
+        .join(", ")}\n\tGot: "${remaining}"`
+    );
+  }
+
+  const { match, tokenType } = matches.reduce((a, b) =>
+    a.match.index <= b.match.index ? a : b
+  );
+  return { match, tokenType };
+}
+
+export function tokenize(formula: string): Token {
+  const rootToken: StartedToken = {
+    start: 0,
+    end: formula.length,
+    type: "group",
+    value: formula,
+    members: [],
+  };
+
+  let currentToken: StartedToken = rootToken;
+  const stack: StartedToken[] = [];
+
+  for (let i = 0; i < formula.length; i++) {
+    const remaining = formula.slice(i);
+
+    const applicableTypes = getApplicableTypes(currentToken);
+    const { match, tokenType } = findNextToken(
+      applicableTypes,
+      remaining,
+      i,
+      currentToken
+    );
+
+    const matchedToken = createTokenFromMatch(tokenType.type, match, i);
+
+    const invalidStr = formula.slice(i, matchedToken.start);
+
+    if (invalidStr) {
+      throw new Error(
+        `Syntax Error: Invalid tokens at position ${i}: ${invalidStr}`
+      );
+    }
+
+    if (isOpening(tokenType)) {
+      const { opens } = tokenType;
+      const openingToken: StartedToken = {
+        type: opens,
+        value: "",
+        start: matchedToken.end,
+        opener: matchedToken,
+        members: [],
+      };
+      stack.push(currentToken);
+      currentToken = openingToken;
+    } else if (isClosing(tokenType)) {
+      const superToken = stack.pop();
+      if (!superToken) {
+        throw new Error(
+          `Syntax Error: Unexpected closing token ${match[0]} at ${i}`
+        );
+      }
+
+      superToken.members.push(closeEnclosedToken(currentToken, matchedToken));
+
+      currentToken = superToken;
+    } else if (isMember(tokenType) || isEnclosed(tokenType)) {
+      const { flatten } = tokenType;
+
+      appendToken(currentToken, matchedToken, isMember(tokenType) && !flatten);
+      i = matchedToken.end - 1;
+    } else {
+      throw new Error(`Syntax Error: Unexpected token ${match[0]} at ${i}`);
+    }
+  }
+
+  if (currentToken !== rootToken) {
+    throw new Error(
+      `SyntaxError: Unclosed token ${currentToken.type}, with ${
+        currentToken.opener?.value
+      } at position ${
+        currentToken.opener?.start
+      }, but no closing token at position ${
+        currentToken.start + currentToken.value.length
+      }`
+    );
+  }
+
+  if (!isToken(rootToken)) {
+    throw new Error("Internal error: Root Token is incomplete");
+  }
+
+  return finalizeToken(rootToken);
+}


### PR DESCRIPTION
# What❓

Added a tokenizer function that will help us to parse the AST for airtable formula. This will eventually allow us to parse a formula string and convert it into a object notated formula.

# Why 💁‍♀️

We still have a many string notated formulas in our repos, which we need to understand better. Being able to parse these formulas, will help us understand which fields these formulas are referencing.

# Todos before it can be reviewed

None

# Todos before it can be merged

None
