### PR TITLE
Add ARRAYSLICE to formula reference

### DIFF
--- a/.changeset/many-laws-agree.md
+++ b/.changeset/many-laws-agree.md
@@ -1,0 +1,5 @@
+---
+"@qualifyze/airtable-formulator": patch
+---
+
+Add ARRAYSLICE to formula reference

--- a/src/airtable-formula-reference.json
+++ b/src/airtable-formula-reference.json
@@ -78,6 +78,7 @@
     "ARRAYCOMPACT": {},
     "ARRAYFLATTEN": {},
     "ARRAYUNIQUE": {},
+    "ARRAYSLICE": {},
     "RECORD_ID": {},
     "REGEX_MATCH": {},
     "REGEX_EXTRACT": {},


### PR DESCRIPTION
# What❓

Added ARRAYSLICE function

I ran `npm run update-reference` to ensure this was the only new function

Thread on its addition: https://community.airtable.com/formulas-10/arrayslice-function-34530

# Why 💁‍♀️

Add support for ARRAYSLICE, to ensure all functions can be used via formulator